### PR TITLE
Fix #10: indicate this is for METS 2; link to METS 1 primer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# METS Primer
+# METS 2 Primer
+
+This guide provides documentation and detailed examples of usage for the Metadata Encoding & Transmission Standard (METS) schema, version 2. [Detailed documentation for METS 1](https://www.loc.gov/standards/mets/METSPrimer.pdf) is also available.
+
+The published version of this site is available at [https://mets.github.io](https://mets.github.io). This site *continues to be a work in progress*, and not all sections have yet been fully updated for METS 2.
 
 * [Introduction and Background](intro_background.md): provides some generation information about the background and development of METS.
 * [Sections of a METS Document](mets_sections.md): provides reference about the various major sections of a METS document.

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: METS Primer
-description: Metadata Encoding and Transmission Standards Primer
+title: METS 2 Primer
+description: Metadata Encoding and Transmission Standard (Version 2) Primer
 author: METS Editorial Board
 remote_theme: just-the-docs/just-the-docs
 

--- a/index.md
+++ b/index.md
@@ -4,11 +4,17 @@ layout: home
 nav_order: 1
 ---
 
-# METS Primer - Home
+# METS 2 Primer - Home
 
-* [Introduction and Background](intro_background.md): provides some generation information about the background and development of METS.
+This guide provides documentation and detailed examples of usage for the Metadata Encoding & Transmission Standard (METS) schema, version 2. [Detailed documentation for METS 1](https://www.loc.gov/standards/mets/METSPrimer.pdf) is also available.
+
+This site *continues to be a work in progress*, and not all sections have yet been fully updated for METS 2.
+
+* [Introduction and Background](intro_background.md): provides some general information about the background and development of METS.
 * [Sections of a METS Document](mets_sections.md): provides reference about the various major sections of a METS document.
 * [Complete Example](complete_example.md): provides a complete worked example of a non-trivial METS document.
 * [METS How-Tos](mets_howtos.md): provides examples of how to use the various elements and attributes of the METS schema for specific purposes.
 * [External schemas and Controlled Vocabularies](external_schema_vocabulary.md): provides an overview of the use of external schemas with METS for the different categories of metadata that can be partitioned within it including descriptive and administrative metadata.  The reader is directed to other sources of information for more specifics regarding the use of each schema that is endorsed by the METS Editorial Board.  
 * [METS Profiles](mets_profiles.md): includes introductory material about METS profiles, but once again points to the more specific information found on the METS website about how to create METS profiles along with the list of registered profiles, and the sample instance documents that are required as part of registering a METS profile.
+
+


### PR DESCRIPTION
Just saying this is for METS 2 on the home page (& repository README) and linking to the METS 1 primer.