### PR TITLE
adjust section title to "Structure section"

### DIFF
--- a/howto/fileGrp.md
+++ b/howto/fileGrp.md
@@ -14,7 +14,7 @@ Meanwhile, the `<structMap>` element can be used to link together the different 
 
 A `<fileGrp>` may contain zero or more `<file>` elements. A `<file>` element may contain `<FLocat>` pointers to one or more external content files via a URI (see [Referencing external files](FLocat.md)) and/or may itself contain the file content as XML or binary data using the `<FContent>` element (see [Embedding file content](FContent.md)).
 
-A nested (hierarchical) arrangement of file groups is not allowed, since complex structures are meant to be described in the structural map section `<structSec>`.
+A nested (hierarchical) arrangement of file groups is not allowed, since complex structures are meant to be described in the structure section `<structSec>`.
 
 ## Example
 

--- a/mets_sections.md
+++ b/mets_sections.md
@@ -14,4 +14,4 @@ Each major section of METS is covered on a separate page:
 * [METS Header](mets_sections/metsHdr.md)
 * [Metadata section](mets_sections/mdSec.md)
 * [File section - fileSec](mets_sections/fileSec.md)
-* [Structural map section](mets_sections/structSec.md)
+* [Structure section](mets_sections/structSec.md)

--- a/mets_sections/root_element.md
+++ b/mets_sections/root_element.md
@@ -26,7 +26,7 @@ At the most general level, a METS document may contain the following sections, e
 
 * [File section - fileSec](fileSec.md) -- A list of all files containing content that make up the electronic versions of the digital object. File elements may be grouped within file group elements, to allow for subdivision of files by object version or other criteria such as file type, size, etc.
 
-* [Structural map section - structSec](structSec.md) -- The structural map section outlines a hierarchical structure for the digital object, and links the elements of that structure to the content files and metadata associated with each element.
+* [Structure section - structSec](structSec.md) -- The structure section outlines a hierarchical structure for the digital object, and links the elements of that structure to the content files and metadata associated with each element.
 
 ## METS root element example
 

--- a/mets_sections/structSec.md
+++ b/mets_sections/structSec.md
@@ -1,11 +1,11 @@
 ---
-title: Structural map section
+title: Structure section
 parent: Sections of a METS Document
 nav_order: 5
 ---
-# Structural map section
+# Structure section
 
-The **structural map section** `<structSec>` provides a means of organizing the digital content represented by the `<file>` elements in the `<fileSec>` of the METS document into a coherent hierarchical structure. (Note that if there is another structure that better suits your needs, that is fine, but hierarchical structures are most commonly used here.) Such a hierarchical structure can be presented to users to help them understand and navigate the digital content. It can also be used for any purpose that requires an understanding of the structural relationship of content files or parts of content files. The organization can be specified at any desired level of granularity (intellectual and/or physical). The section may contain one or more structural maps, using a repeatable `<structMap>` element that allows more than one structure to apply to the digital content represented by the METS document.
+The **structure section** `<structSec>` provides a means of organizing the digital content represented by the `<file>` elements in the `<fileSec>` of the METS document into a coherent hierarchical structure. (Note that if there is another structure that better suits your needs, that is fine, but hierarchical structures are most commonly used here.) Such a hierarchical structure can be presented to users to help them understand and navigate the digital content. It can also be used for any purpose that requires an understanding of the structural relationship of content files or parts of content files. The organization can be specified at any desired level of granularity (intellectual and/or physical). The section may contain one or more structural maps, using a repeatable `<structMap>` element that allows more than one structure to apply to the digital content represented by the METS document.
 
 The structure provided by the `<structMap>` element may be purely intellectual or logical (such as a book divided into chapters), purely physical (a book divided into sequences of pages), or a mixture of logical and physical (a book divided into chapters and then into a sequence of pages). The content organized by the `<structMap>` can include many mixtures of digital content files: structured or unstructured text, image, audio, video, and/or application (such as PDF).
 
@@ -15,7 +15,7 @@ In addition to providing a means for organizing content, the `<structMap>` also 
 
 The hierarchical structure specified by a `<structMap>` is encoded as a tree of nested `<div>` elements. A `<div>` element may point directly to content via child file pointer (`<fptr>`) elements (if the content is represented in the `<fileSec>`) or via child METS pointer (`<mptr>`) elements (if the content is represented by an external METS document). The `<fptr>` element may point to a single `<file>` element that manifests its parent `<div>`, or point to part of a `<file>` that manifests its `<div>`. It can also point to multiple files or parts of files, which must be played or displayed either in sequence or in parallel to render the structural division. The `<div>`, `<mptr>`, `<fptr>`, and other `<structMap>` elements that enable this sophisticated structuring are described in detail on their own pages (see [Structuring and Linking](../mets_howtos.md#structuring-and-linking))
 
-The example encodings in this structural map section demonstrate a variety of ways to structure a digital version of the Martial *Epigrams*, some more plausible than others. The main goal is not to present definitive encodings, but rather just to showcase the flexibility and variety of the structural mechanisms offered by METS. The best structural choices for a particular work depend on several factors: the nature of the work being digitized, the anticipated users of the digital version, the type(s) of presentation desired, the capabilities of the available presentation tools, etc.
+The example encodings in this structure section demonstrate a variety of ways to structure a digital version of the Martial *Epigrams*, some more plausible than others. The main goal is not to present definitive encodings, but rather just to showcase the flexibility and variety of the structural mechanisms offered by METS. The best structural choices for a particular work depend on several factors: the nature of the work being digitized, the anticipated users of the digital version, the type(s) of presentation desired, the capabilities of the available presentation tools, etc.
 
 ## More Information
 


### PR DESCRIPTION
Just a detail, but it seems that the label of the entire section should not use the "map" term which is part of a subelement.